### PR TITLE
Add openAPI project support to travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ script:
 after_success:
   - cd ${TRAVIS_BUILD_DIR}
   - rm -rf ${projectFolder}
-  - ./updateRepo.sh
+  - ./update.sh
 after_failure:
   - cd ${TRAVIS_BUILD_DIR}
   - rm -rf ${projectFolder}

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,7 @@ before_script:
   - osName="linux"
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then osName="osx"; fi
 script:
-  - source generateProject.sh
-  - ${projectFolder}/Package-Builder/build-package.sh -projectDir ${projectFolder}
+  - source testProjects.sh
 after_success:
   - cd ${TRAVIS_BUILD_DIR}
   - rm -rf ${projectFolder}

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ script:
 after_success:
   - cd ${TRAVIS_BUILD_DIR}
   - rm -rf ${projectFolder}
-  - if [ "$TRAVIS_BRANCH" = "master" ]; then ./update.sh; fi
+  - if [[ "$TRAVIS_BRANCH" = "master" && "$TRAVIS_PULL_REQUEST" = "false" ]]; then ./update.sh; fi
 after_failure:
   - cd ${TRAVIS_BUILD_DIR}
   - rm -rf ${projectFolder}

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ script:
 after_success:
   - cd ${TRAVIS_BUILD_DIR}
   - rm -rf ${projectFolder}
-  - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then ./update.sh; fi
+  - if [ "$TRAVIS_BRANCH" = "master" ]; then ./update.sh; fi
 after_failure:
   - cd ${TRAVIS_BUILD_DIR}
   - rm -rf ${projectFolder}

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ script:
 after_success:
   - cd ${TRAVIS_BUILD_DIR}
   - rm -rf ${projectFolder}
-  - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then ./update.sh
+  - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then ./update.sh; fi
 after_failure:
   - cd ${TRAVIS_BUILD_DIR}
   - rm -rf ${projectFolder}

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ script:
 after_success:
   - cd ${TRAVIS_BUILD_DIR}
   - rm -rf ${projectFolder}
-  - ./update.sh
+  - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then ./update.sh
 after_failure:
   - cd ${TRAVIS_BUILD_DIR}
   - rm -rf ${projectFolder}

--- a/generateProject.sh
+++ b/generateProject.sh
@@ -1,9 +1,0 @@
-export projectName="Generator-Swiftserver-Projects"
-cd ${TRAVIS_BUILD_DIR}
-mkdir ${projectName}
-cd ${projectName}
-export projectFolder=`pwd`
-echo "Generating project"
-yo swiftserver --init --skip-build
-echo "Testing swiftserver generated project"
-git clone https://github.com/IBM-Swift/Package-Builder.git

--- a/testProjects.sh
+++ b/testProjects.sh
@@ -1,0 +1,21 @@
+export projectName="Generator-Swiftserver-Projects"
+cd ${TRAVIS_BUILD_DIR}
+mkdir ${projectName}
+cd ${projectName}
+export projectFolder=`pwd`
+
+for branch in "init" "openAPI"
+do
+  mkdir ${projectFolder}/${branch}
+  cd ${projectFolder}/${branch}
+  echo "Generating project"
+  case "$branch" in
+       init) yo swiftserver --init --skip-build ;;
+    openAPI) yo swiftserver --app --skip-build --spec \
+            '{ "appName": "'${projectName}'", "appType": "scaffold", "appDir": ".", "openapi": true, "docker": true, "metrics": true, "healthcheck": true }' ;;
+          *) echo "Cannot generate project for this type." ;;
+  esac
+  echo "Testing '${branch}' swiftserver generated project"
+  git clone https://github.com/IBM-Swift/Package-Builder.git
+  ${projectFolder}/${branch}/Package-Builder/build-package.sh -projectDir ${projectFolder}/${branch}
+done

--- a/update.sh
+++ b/update.sh
@@ -15,9 +15,3 @@ do
   export BRANCH=${branch}
   ${scriptDir}/updateRepo.sh
 done
-#
-# export BRANCH="init"
-# ${scriptDir}/updateRepo.sh
-#
-# export BRANCH="openAPI"
-# ${scriptDir}/updateRepo.sh

--- a/update.sh
+++ b/update.sh
@@ -1,0 +1,23 @@
+echo "Checking if repo needs to be updated"
+export ORG="IBM-Swift"
+export REPO="generator-swiftserver-projects"
+export GH_REPO="github.com/${ORG}/${REPO}.git"
+export projectName="Generator-Swiftserver-Projects"
+export scriptDir=`pwd`
+
+mkdir ${TRAVIS_BUILD_DIR}/current
+cd ${TRAVIS_BUILD_DIR}/current
+export currentProject=`pwd`
+git clone "https://${GITHUB_USERNAME}:${GITHUB_PASSWORD}@github.com/${ORG}/${REPO}.git"
+
+for branch in "init" "openAPI"
+do
+  export BRANCH=${branch}
+  ${scriptDir}/updateRepo.sh
+done
+#
+# export BRANCH="init"
+# ${scriptDir}/updateRepo.sh
+#
+# export BRANCH="openAPI"
+# ${scriptDir}/updateRepo.sh

--- a/updateRepo.sh
+++ b/updateRepo.sh
@@ -9,7 +9,7 @@ cd ${newProject}/${BRANCH}/${projectName}
 case "$BRANCH" in
      init) yo swiftserver --init --skip-build ;;
   openAPI) yo swiftserver --app --skip-build --spec \
-          '{ "appName": "MyProject", "appType": "scaffold", "appDir": ".", "openapi": true, "docker": true, "metrics": true, "healthcheck": true }' ;;
+          '{ "appName": "'${projectName}'", "appType": "scaffold", "appDir": ".", "openapi": true, "docker": true, "metrics": true, "healthcheck": true }' ;;
         *) echo "Cannot generate project for this type." ;;
 esac
 

--- a/updateRepo.sh
+++ b/updateRepo.sh
@@ -1,33 +1,31 @@
-echo "Checking if repo needs to be updated"
-export ORG="IBM-Swift"
-export REPO="generator-swiftserver-projects"
-export GH_REPO="github.com/${ORG}/${REPO}.git"
-export BRANCH="init"
-export projectName="Generator-Swiftserver-Projects"
+cd ${currentProject}/${REPO}
+git checkout ${BRANCH}
 
-cd ${TRAVIS_BUILD_DIR}
-mkdir current
-cd current
-git clone -b ${BRANCH} "https://${GITHUB_USERNAME}:${GITHUB_PASSWORD}@github.com/${ORG}/${REPO}.git"
-export currentProject=`pwd`
-
-mkdir -p ../new/${projectName}
-cd ../new/${projectName}
-yo swiftserver --init --skip-build
-echo "Generate README rtf"
-pandoc README.md -f markdown_github -t rtf -so README.rtf
-cd ../
+mkdir -p ${TRAVIS_BUILD_DIR}/new/${BRANCH}/${projectName}
+cd ${TRAVIS_BUILD_DIR}/new
 export newProject=`pwd`
 
-if diff -x '.git' -r ${currentProject}/${REPO} ${newProject}/${projectName}
+case "$BRANCH" in
+     init) yo swiftserver --init --skip-build ;;
+  openAPI) echo "openAPI!" ;;
+        *) echo "Cannot generate project for this type." ;;
+esac
+
+echo "Generate README rtf"
+pandoc README.md -f gfm -t rtf -so README.rtf
+cd ../
+
+
+if diff -x '.git' -r ${currentProject}/${REPO} ${newProject}/${BRANCH}/${projectName}
 then
   echo "Project does not need to be updated"
-  rm -rf ${currentProject}/${REPO} ${newProject}/${projectName}
+  rm -rf ${currentProject}/${REPO} ${newProject}/${BRANCH}/${projectName}
   exit 1
 fi
 
 echo "Project needs to be updated"
-cp -r ${newProject}/${projectName}/. ${currentProject}/${REPO}
+exit 1
+cp -r ${newProject}/${BRANCH}/${projectName}/. ${currentProject}/${REPO}
 cd ${currentProject}/${REPO}
 git add .
 git commit -m "CRON JOB: Updating generated project"

--- a/updateRepo.sh
+++ b/updateRepo.sh
@@ -14,7 +14,7 @@ case "$BRANCH" in
 esac
 
 echo "Generate README rtf"
-pandoc README.md -f gfm -t rtf -so README.rtf
+pandoc README.md -f markdown_github -t rtf -so README.rtf
 cd ../
 
 

--- a/updateRepo.sh
+++ b/updateRepo.sh
@@ -5,9 +5,11 @@ mkdir -p ${TRAVIS_BUILD_DIR}/new/${BRANCH}/${projectName}
 cd ${TRAVIS_BUILD_DIR}/new
 export newProject=`pwd`
 
+cd ${newProject}/${BRANCH}/${projectName}
 case "$BRANCH" in
      init) yo swiftserver --init --skip-build ;;
-  openAPI) echo "openAPI!" ;;
+  openAPI) yo swiftserver --app --skip-build --spec \
+          '{ "appName": "MyProject", "appType": "scaffold", "appDir": ".", "openapi": true, "docker": true, "metrics": true, "healthcheck": true }' ;;
         *) echo "Cannot generate project for this type." ;;
 esac
 
@@ -24,7 +26,6 @@ then
 fi
 
 echo "Project needs to be updated"
-exit 1
 cp -r ${newProject}/${BRANCH}/${projectName}/. ${currentProject}/${REPO}
 cd ${currentProject}/${REPO}
 git add .


### PR DESCRIPTION
Travis CI should now take `openAPI` branch into account and make sure that it is kept updated. This branch will be used as a third tile in the macOS application.