### PR TITLE
Remove line breaks

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,11 +11,8 @@ let package = Package(
       .package(url: "https://github.com/IBM-Swift/Health.git", from: "1.0.0"),
     ],
     targets: [
-      .target(name: "Generator-Swiftserver-Projects", dependencies: [ .target(name: "Application"), "Kitura" , "HeliumLogger"]),
-      .target(name: "Application", dependencies: [ "Kitura", "CloudEnvironment","SwiftMetrics", "Health", 
-
-      ]),
-
-      .testTarget(name: "ApplicationTests" , dependencies: [.target(name: "Application"), "Kitura","HeliumLogger" ])
+      .target(name: "Generator-Swiftserver-Projects", dependencies: [.target(name: "Application"), "Kitura" , "HeliumLogger"]),
+      .target(name: "Application", dependencies: ["Kitura", "CloudEnvironment", "Health", "SwiftMetrics"]),
+      .testTarget(name: "ApplicationTests" , dependencies: [.target(name: "Application"), "Kitura","HeliumLogger"])
     ]
 )


### PR DESCRIPTION
Generally not needed line breaks/spaces/commas, can cause an issue when following ToDoBackend workshop as copying in OpenAPI dependency will introduce an additional closing bracket.

I know it would be simpler/less invasive to change the workshop - but I think whats in the workshop is correct