### PR TITLE
Add nightly cron jobs for openAPI branch

### DIFF
--- a/updateRepo.sh
+++ b/updateRepo.sh
@@ -15,6 +15,7 @@ FAIL=""    # List of failed updates
 # Builds a list of branchs that failed to update (if any)
 function fail () {
   FAIL="$FAIL $1" && echo "Failed to push to branch: $BRANCH"
+  return 1
 }
 
 for BRANCH in $BRANCHES

--- a/updateRepo.sh
+++ b/updateRepo.sh
@@ -55,7 +55,7 @@ do
   fi
 
   echo "Project needs to be updated"
-  rsync -av --checksum "${newRepo}/" "${currentRepo}"
+  rsync -av --ignore-times "${newRepo}/" "${currentRepo}"
   cd "${currentRepo}"
   git add -A
   git commit -m "CRON JOB: Updating generated project"

--- a/updateRepo.sh
+++ b/updateRepo.sh
@@ -2,33 +2,47 @@ echo "Checking if repo needs to be updated"
 export ORG="IBM-Swift"
 export REPO="generator-swiftserver-projects"
 export GH_REPO="github.com/${ORG}/${REPO}.git"
-export BRANCH="init"
+export BRANCHES="init openAPI"
 export projectName="Generator-Swiftserver-Projects"
 
-cd ${TRAVIS_BUILD_DIR}
-mkdir current
-cd current
-git clone -b ${BRANCH} "https://${GITHUB_USERNAME}:${GITHUB_PASSWORD}@github.com/${ORG}/${REPO}.git"
-export currentProject=`pwd`
+for BRANCH in $BRANCHES
+do
+  cd ${TRAVIS_BUILD_DIR}
+  mkdir current
+  cd current
+  git clone -b ${BRANCH} "https://${GITHUB_USERNAME}:${GITHUB_PASSWORD}@github.com/${ORG}/${REPO}.git"
+  export currentProject=`pwd`
 
-mkdir -p ../new/${projectName}
-cd ../new/${projectName}
-yo swiftserver --init --skip-build
-echo "Generate README rtf"
-pandoc README.md -f markdown_github -t rtf -so README.rtf
-cd ../
-export newProject=`pwd`
+  mkdir -p ${TRAVIS_BUILD_DIR}/new/${projectName}
+  cd ${TRAVIS_BUILD_DIR}/new/${projectName}
+  if [[ ${BRANCH} == "init" ]]
+  then
+    yo swiftserver --init --skip-build
+  elif [[ $BRANCH == "openAPI" ]]
+  then
+    yo swiftserver --app --spec '{ "appName":"'"$projectName"'", "appType":"scaffold", "appDir":".", "openapi":true, "docker":true, "metrics":true, "healthcheck":true }' --skip-build
+  fi
 
-if diff -x '.git' -r ${currentProject}/${REPO} ${newProject}/${projectName}
-then
-  echo "Project does not need to be updated"
-  rm -rf ${currentProject}/${REPO} ${newProject}/${projectName}
-  exit 1
-fi
+  rm spec.json
+  echo "Generate README rtf"
+  pandoc README.md -f markdown_github -t rtf -so README.rtf
+  cd ${TRAVIS_BUILD_DIR}/new
+  export newProject=`pwd`
 
-echo "Project needs to be updated"
-cp -r ${newProject}/${projectName}/. ${currentProject}/${REPO}
-cd ${currentProject}/${REPO}
-git add .
-git commit -m "CRON JOB: Updating generated project"
-git push origin ${BRANCH}
+  if diff -x '.git' -r ${currentProject}/${REPO} ${newProject}/${projectName}
+  then
+    echo "Project does not need to be updated"
+    rm -rf ${currentProject}/${REPO} ${newProject}/${projectName}
+    exit 1
+  fi
+
+  echo "Project needs to be updated"
+  cp -r ${newProject}/${projectName}/. ${currentProject}/${REPO}
+  cd ${currentProject}/${REPO}
+  git add .
+  git commit -m "CRON JOB: Updating generated project"
+  git push origin ${BRANCH}
+  cd ${TRAVIS_BUILD_DIR}
+  rm -rf current
+  rm -rf new
+done

--- a/updateRepo.sh
+++ b/updateRepo.sh
@@ -55,7 +55,7 @@ do
   fi
 
   echo "Project needs to be updated"
-  rsync -av --ignore-existing "${newRepo}/" "${currentRepo}"
+  rsync -av --ignore-timestamp "${newRepo}/" "${currentRepo}/"
   cd "${currentRepo}"
   git add -A
   git commit -m "CRON JOB: Updating generated project"

--- a/updateRepo.sh
+++ b/updateRepo.sh
@@ -55,7 +55,7 @@ do
   fi
 
   echo "Project needs to be updated"
-  rsync -av --update --ignore-times "${newRepo}/." "${currentRepo}"
+  rsync -av --checksum "${newRepo}/" "${currentRepo}"
   cd "${currentRepo}"
   git add -A
   git commit -m "CRON JOB: Updating generated project"

--- a/updateRepo.sh
+++ b/updateRepo.sh
@@ -2,7 +2,7 @@
 set -ex
 
 echo "Checking if repo needs to be updated"
-echo "----------- ${TRAVIS_REPO_SLUG} -------------"
+
 if [[ $TRAVIS == true ]]
 then GH_REPO="github.com/${TRAVIS_REPO_SLUG}.git"
 else 
@@ -32,7 +32,7 @@ do
   cd "${TRAVIS_BUILD_DIR}"
   rm -rf current
   rm -rf new
-  git clone -b "${BRANCH}" "https://${GITHUB_USERNAME}:${GITHUB_PASSWORD}@github.com/${ORG}/${REPO}.git" current
+  git clone -b "${BRANCH}" "https://${GITHUB_USERNAME}:${GITHUB_PASSWORD}@${GH_REPO}" current
   currentProject="$(pwd)/current"
 
   # Need to create a project directory and move into it so we can run the generator.

--- a/updateRepo.sh
+++ b/updateRepo.sh
@@ -2,6 +2,7 @@
 set -ex
 
 echo "Checking if repo needs to be updated"
+echo "----------- ${TRAVIS_REPO_SLUG} -------------"
 if [[ $TRAVIS == true ]]
 then GH_REPO="github.com/${TRAVIS_REPO_SLUG}.git"
 else 

--- a/updateRepo.sh
+++ b/updateRepo.sh
@@ -3,7 +3,7 @@ set -e
 set -x
 
 echo "Checking if repo needs to be updated"
-ORG="IBM-Swift"
+ORG="ddunn2"
 REPO="generator-swiftserver-projects"
 GH_REPO="github.com/${ORG}/${REPO}.git"
 BRANCHES="init openAPI"
@@ -24,7 +24,7 @@ do
   rm -rf new
   mkdir current
   cd current
-  git clone -b "${BRANCH}" "https://${GITHUB_USERNAME}:${GITHUB_PASSWORD}@github.com/${ORG}/${REPO}.git"
+  git clone -b "${BRANCH}" "https://ddunn2:${GITHUB_PASS}@github.com/${ORG}/${REPO}.git"
   currentProject=$(pwd)
 
   mkdir -p "${TRAVIS_BUILD_DIR}/new/${projectName}"

--- a/updateRepo.sh
+++ b/updateRepo.sh
@@ -55,7 +55,7 @@ do
   fi
 
   echo "Project needs to be updated"
-  rsync -av --ignore-timestamp "${newRepo}/" "${currentRepo}/"
+  rsync -av --ignore-times "${newRepo}/" "${currentRepo}/"
   cd "${currentRepo}"
   git add -A
   git commit -m "CRON JOB: Updating generated project"

--- a/updateRepo.sh
+++ b/updateRepo.sh
@@ -55,7 +55,7 @@ do
   fi
 
   echo "Project needs to be updated"
-  rsync -av --size-only "${newRepo}/" "${currentRepo}"
+  rsync -av --ignore-existing "${newRepo}/" "${currentRepo}"
   cd "${currentRepo}"
   git add -A
   git commit -m "CRON JOB: Updating generated project"

--- a/updateRepo.sh
+++ b/updateRepo.sh
@@ -19,6 +19,7 @@ function fail () {
 
 for BRANCH in $BRANCHES
 do
+  echo "Generating project for ${BRANCH}"
   cd "${TRAVIS_BUILD_DIR}"
   rm -rf current
   rm -rf new

--- a/updateRepo.sh
+++ b/updateRepo.sh
@@ -55,8 +55,7 @@ do
   fi
 
   echo "Project needs to be updated"
-  rm -rf "${currentRepo}"
-  cp -r "${newRepo}/." "${currentRepo}"
+  rsync -av --update "${newRepo}/." "${currentRepo}"
   cd "${currentRepo}"
   git add -A
   git commit -m "CRON JOB: Updating generated project"

--- a/updateRepo.sh
+++ b/updateRepo.sh
@@ -55,7 +55,7 @@ do
   fi
 
   echo "Project needs to be updated"
-  rsync -av --update "${newRepo}/." "${currentRepo}"
+  rsync -av --update --ignore-times "${newRepo}/." "${currentRepo}"
   cd "${currentRepo}"
   git add -A
   git commit -m "CRON JOB: Updating generated project"

--- a/updateRepo.sh
+++ b/updateRepo.sh
@@ -2,9 +2,17 @@
 set -ex
 
 echo "Checking if repo needs to be updated"
-ORG="IBM-Swift"
-REPO="generator-swiftserver-projects"
-GH_REPO="github.com/${ORG}/${REPO}.git"
+if [[ $TRAVIS == true ]]
+then GH_REPO="github.com/${TRAVIS_REPO_SLUG}.git"
+else 
+  # If running locally set ORG to the Org of your fork.
+  ORG="<my-org>"
+  REPO="generator-swiftserver-projects"
+  GH_REPO="github.com/${ORG}/${REPO}.git"
+fi
+
+echo GH_REPO
+
 BRANCHES="init openAPI"
 projectName="Generator-Swiftserver-Projects"
 
@@ -51,8 +59,8 @@ do
   if diff -x '.git' -r "${currentRepo}" "${newRepo}"
   then
     echo "Project does not need to be updated"
-    rm -rf "${currentRepo}" "${newRepo}"
-    exit 1
+    rm -rf "${currentProject}" "${newProject}"
+    continue
   fi
 
   echo "Project needs to be updated"
@@ -60,7 +68,9 @@ do
   cd "${currentRepo}"
   git add -A
   git commit -m "CRON JOB: Updating generated project"
-  git push origin "${BRANCH}" || fail "${BRANCH}" || continue
+  if $TRAVIS_PULL_REQUEST == false 
+  then git push origin "${BRANCH}" || fail "${BRANCH}" || continue
+  fi
   SUCCESS="$SUCCESS $BRANCH"
 done
 

--- a/updateRepo.sh
+++ b/updateRepo.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 echo "Checking if repo needs to be updated"
 export ORG="IBM-Swift"
 export REPO="generator-swiftserver-projects"
@@ -7,18 +9,18 @@ export projectName="Generator-Swiftserver-Projects"
 
 for BRANCH in $BRANCHES
 do
-  cd ${TRAVIS_BUILD_DIR}
+  cd "${TRAVIS_BUILD_DIR}" || exit
   mkdir current
-  cd current
-  git clone -b ${BRANCH} "https://${GITHUB_USERNAME}:${GITHUB_PASSWORD}@github.com/${ORG}/${REPO}.git"
-  export currentProject=`pwd`
+  cd current || exit
+  git clone -b "${BRANCH}" "https://${GITHUB_USERNAME}:${GITHUB_PASSWORD}@github.com/${ORG}/${REPO}.git"
+  currentProject=$(pwd)
 
-  mkdir -p ${TRAVIS_BUILD_DIR}/new/${projectName}
-  cd ${TRAVIS_BUILD_DIR}/new/${projectName}
-  if [[ ${BRANCH} == "init" ]]
+  mkdir -p "${TRAVIS_BUILD_DIR}/new/${projectName}"
+  cd "${TRAVIS_BUILD_DIR}/new/${projectName}" || exit
+  if [[ "${BRANCH}" == "init" ]]
   then
     yo swiftserver --init --skip-build
-  elif [[ $BRANCH == "openAPI" ]]
+  elif [[ "$BRANCH" == "openAPI" ]]
   then
     yo swiftserver --app --spec '{ "appName":"'"$projectName"'", "appType":"scaffold", "appDir":".", "openapi":true, "docker":true, "metrics":true, "healthcheck":true }' --skip-build
   fi
@@ -26,23 +28,26 @@ do
   rm spec.json
   echo "Generate README rtf"
   pandoc README.md -f markdown_github -t rtf -so README.rtf
-  cd ${TRAVIS_BUILD_DIR}/new
-  export newProject=`pwd`
+  cd "${TRAVIS_BUILD_DIR}"/new || exit
+  newProject=$(pwd)
 
-  if diff -x '.git' -r ${currentProject}/${REPO} ${newProject}/${projectName}
+  currentRepo="${currentProject}/${REPO}"
+  newRepo="${newProject}/${projectName}"
+
+  if diff -x '.git' -r "${currentRepo}" "${newRepo}"
   then
     echo "Project does not need to be updated"
-    rm -rf ${currentProject}/${REPO} ${newProject}/${projectName}
+    rm -rf "${currentRepo}" "${newRepo}"
     exit 1
   fi
 
   echo "Project needs to be updated"
-  cp -r ${newProject}/${projectName}/. ${currentProject}/${REPO}
-  cd ${currentProject}/${REPO}
+  cp -r "${newProject}/${projectName}/." "${currentProject}/${REPO}"
+  cd "${currentProject}/${REPO}" || exit
   git add .
   git commit -m "CRON JOB: Updating generated project"
-  git push origin ${BRANCH}
-  cd ${TRAVIS_BUILD_DIR}
+  git push origin "${BRANCH}"
+  cd "${TRAVIS_BUILD_DIR}" || exit
   rm -rf current
   rm -rf new
 done

--- a/updateRepo.sh
+++ b/updateRepo.sh
@@ -55,7 +55,7 @@ do
   fi
 
   echo "Project needs to be updated"
-  rsync -av --ignore-times "${newRepo}/" "${currentRepo}"
+  rsync -av --size-only "${newRepo}/" "${currentRepo}"
   cd "${currentRepo}"
   git add -A
   git commit -m "CRON JOB: Updating generated project"

--- a/updateRepo.sh
+++ b/updateRepo.sh
@@ -2,7 +2,7 @@
 set -ex
 
 echo "Checking if repo needs to be updated"
-ORG="ddunn2"
+ORG="IBM-Swift"
 REPO="generator-swiftserver-projects"
 GH_REPO="github.com/${ORG}/${REPO}.git"
 BRANCHES="init openAPI"
@@ -22,7 +22,7 @@ do
   cd "${TRAVIS_BUILD_DIR}"
   rm -rf current
   rm -rf new
-  git clone -b "${BRANCH}" "https://ddunn2:${GITHUB_PASS}@github.com/${ORG}/${REPO}.git" current
+  git clone -b "${BRANCH}" "https://${GITHUB_USERNAME}:${GITHUB_PASSWORD}@github.com/${ORG}/${REPO}.git" current
   currentProject="$(pwd)/current"
 
   # Need to create a project directory and move into it so we can run the generator.


### PR DESCRIPTION
This PR adds the nightly chron builds to the `openAPI` branch as well as the `init` branch. 

I've attempted to do this in a way to future proof the addition of other branches in the future. 

As a part of this PR I also removed any instances of using `cd ../` and used absolute paths instead. 