### PR TITLE
Update basic project Kitura version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     name: "generator-swiftserver-projects",
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/IBM-Swift/Kitura.git", .upToNextMinor(from: "2.5.0")),
+        .package(url: "https://github.com/IBM-Swift/Kitura.git", from: "2.5.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     name: "generator-swiftserver-projects",
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/IBM-Swift/Kitura.git", from: "2.5.0"),
+        .package(url: "https://github.com/IBM-Swift/Kitura.git", from: "2.6.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.


### PR DESCRIPTION
This PR updates the Package.swift on the `basic` branch to use the `from` keyword for versioning. This ensures the project will use the latest minor version of Kitura (now 2.6). 

