### PR TITLE
Fix conditional travis PR check

### DIFF
--- a/updateRepo.sh
+++ b/updateRepo.sh
@@ -69,7 +69,7 @@ do
   cd "${currentRepo}"
   git add -A
   git commit -m "CRON JOB: Updating generated project"
-  if $TRAVIS_PULL_REQUEST == false 
+  if [[ "$TRAVIS_PULL_REQUEST" == "false" ]]
   then git push origin "${BRANCH}" || fail "${BRANCH}" || continue
   fi
   SUCCESS="$SUCCESS $BRANCH"


### PR DESCRIPTION
This PR fixes an issue in the `updateRepo.sh` script where updates are not being pushed to the `init` or `openapi` branches. 

The issue seems to be that `${TRAVIS_PULL_REQUEST}` does not equal `false`, so using `${TRAVIS_PULL_REQUEST} == false` was insufficient. 

Instead we now wrap both sides of the conditional in quotes therefore doing the comparison on Strings. 