### PR TITLE
fix: Ensure updateRepo script deletes unneeded files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,55 @@
+# Convenience Dockerfile to make it easy to replicate the Travis build locally.
+# Build this using `docker build`, then run it to get a shell.
+#
+# From the container shell, run the `updateRepo.sh` script. This will execute
+# the project update process, but will not commit the changes. You can inspect
+# what the script has done by looking in the /project/current/<branch name> dirs.
+#
+FROM swift:5.0.2
+
+# Fix python directories in base image
+RUN if [ -d "/usr/lib/python2.7/site-packages" ]; then mv /usr/lib/python2.7/site-packages/* /usr/lib/python2.7/dist-packages && rmdir /usr/lib/python2.7/site-packages && ln -s dist-packages /usr/lib/python2.7/site-packages ; fi
+
+# Install basic dependencies
+RUN apt-get install -y curl
+# Install Kitura dependencies
+RUN apt-get update && apt-get install -y libssl-dev libcurl4-openssl-dev
+# Install convenience dependencies
+RUN apt-get install -y vim
+
+# Install Node 10 (our version of Yeoman doesn't support Node 12)
+RUN curl -sLO https://deb.nodesource.com/setup_10.x && bash ./setup_10.x && rm ./setup_10.x
+RUN apt-get install -y nodejs
+# Install generator dependencies
+RUN apt-get install -y pandoc rsync
+
+# Become a regular user
+RUN useradd -u 1000 kitura && mkdir -p /home/kitura && chown -R kitura: /home/kitura
+USER kitura
+
+# Install generator and dependencies
+RUN npm config set prefix /home/kitura
+RUN npm install -g yo generator-swiftserver markdown-pdf
+
+# Add NPM locations to path
+ENV PATH=/home/kitura/bin:$PATH
+ENV LD_LIBRARY_PATH=/home/kitura/lib:$LD_LIBRARY_PATH
+
+# Copy generator-swiftserver-projects into image`
+COPY --chown=kitura:kitura . /project
+WORKDIR /project
+ENV TRAVIS_BUILD_DIR=/project
+
+# Test project generation
+RUN ./generateProject.sh
+
+# Test generated project can be built
+WORKDIR /project/Generator-Swiftserver-Projects
+# Set the swift version to match this Dockerfile
+RUN echo "5.0.2" > .swift-version
+# Use Package-Builder to build the project and run the tests
+RUN Package-Builder/build-package.sh -projectDir .
+
+# Prepare to run the updateRepo script.
+WORKDIR /project
+CMD echo "Edit ./updateRepo.sh to replace <my-org> with your Github fork, then run it." && /bin/bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,31 +5,33 @@
 # the project update process, but will not commit the changes. You can inspect
 # what the script has done by looking in the /project/current/<branch name> dirs.
 #
-FROM swift:5.0.2
+FROM swift:5.0.2 AS base
 
 # Fix python directories in base image
-RUN if [ -d "/usr/lib/python2.7/site-packages" ]; then mv /usr/lib/python2.7/site-packages/* /usr/lib/python2.7/dist-packages && rmdir /usr/lib/python2.7/site-packages && ln -s dist-packages /usr/lib/python2.7/site-packages ; fi
+RUN if [ -d "/usr/lib/python2.7/site-packages" ]; then \
+  mv /usr/lib/python2.7/site-packages/* /usr/lib/python2.7/dist-packages \
+    && rmdir /usr/lib/python2.7/site-packages \
+    && ln -s dist-packages /usr/lib/python2.7/site-packages \
+  ; fi
 
-# Install basic dependencies
-RUN apt-get install -y curl
-# Install Kitura dependencies
-RUN apt-get update && apt-get install -y libssl-dev libcurl4-openssl-dev
-# Install convenience dependencies
-RUN apt-get install -y vim
-
-# Install Node 10 (our version of Yeoman doesn't support Node 12)
-RUN curl -sLO https://deb.nodesource.com/setup_10.x && bash ./setup_10.x && rm ./setup_10.x
-RUN apt-get install -y nodejs
-# Install generator dependencies
-RUN apt-get install -y pandoc rsync
+# Install dependencies (vim included for convenience)
+# Install Node 10 (our version of Yeoman doesn't support Node 12) and generator dependencies
+RUN apt-get update \
+  && apt-get install -y libssl-dev libcurl4-openssl-dev curl vim \
+  && curl -sLO https://deb.nodesource.com/setup_10.x \
+  && bash ./setup_10.x \
+  && rm ./setup_10.x \
+  && apt-get install -y nodejs pandoc rsync
 
 # Become a regular user
-RUN useradd -u 1000 kitura && mkdir -p /home/kitura && chown -R kitura: /home/kitura
+RUN useradd -u 1000 kitura \
+  && mkdir -p /home/kitura \
+  && chown -R kitura: /home/kitura
 USER kitura
 
 # Install generator and dependencies
-RUN npm config set prefix /home/kitura
-RUN npm install -g yo generator-swiftserver markdown-pdf
+RUN npm config set prefix /home/kitura \
+  && npm install -g yo generator-swiftserver markdown-pdf
 
 # Add NPM locations to path
 ENV PATH=/home/kitura/bin:$PATH
@@ -38,7 +40,12 @@ ENV LD_LIBRARY_PATH=/home/kitura/lib:$LD_LIBRARY_PATH
 # Copy generator-swiftserver-projects into image`
 COPY --chown=kitura:kitura . /project
 WORKDIR /project
-ENV TRAVIS_BUILD_DIR=/project
+
+
+#
+# Test project generation
+#
+FROM base AS test
 
 # Test project generation
 RUN ./generateProject.sh
@@ -46,9 +53,15 @@ RUN ./generateProject.sh
 # Test generated project can be built
 WORKDIR /project/Generator-Swiftserver-Projects
 # Set the swift version to match this Dockerfile
-RUN echo "5.0.2" > .swift-version
 # Use Package-Builder to build the project and run the tests
-RUN Package-Builder/build-package.sh -projectDir .
+RUN echo "5.0.2" > .swift-version \
+  && Package-Builder/build-package.sh -projectDir .
+
+
+#
+# Build image ready for executing updateRepo script
+#
+FROM base AS run
 
 # Prepare to run the updateRepo script.
 WORKDIR /project

--- a/generateProject.sh
+++ b/generateProject.sh
@@ -1,5 +1,10 @@
+#!/bin/bash
 export projectName="Generator-Swiftserver-Projects"
-cd ${TRAVIS_BUILD_DIR}
+
+if [[ $TRAVIS == true ]]; then
+  cd ${TRAVIS_BUILD_DIR}
+fi
+
 mkdir ${projectName}
 cd ${projectName}
 export projectFolder=`pwd`

--- a/updateRepo.sh
+++ b/updateRepo.sh
@@ -83,7 +83,8 @@ do
   git add -A
   if [[ "$TRAVIS_PULL_REQUEST" == "false" ]]
   then
-    git commit -m "CRON JOB: Updating generated project"
+    generatorVersion=`grep 'version' .yo-rc.json | sed -e's#.*"\([0-9\.]*\)"#\1#'`
+    git commit -m "CRON JOB: Updating project (generator: ${generatorVersion})"
     git push origin "${BRANCH}"
   else
     echo "Skipping push (not a cron job). Changes can be inspected in:"

--- a/updateRepo.sh
+++ b/updateRepo.sh
@@ -1,10 +1,9 @@
 #!/bin/bash
 set -ex
 
-echo "Checking if repo needs to be updated"
-
 if [[ $TRAVIS == true ]]
-then GH_REPO="github.com/${TRAVIS_REPO_SLUG}.git"
+then
+  GH_REPO="github.com/${TRAVIS_REPO_SLUG}.git"
 else 
   # If running locally set ORG to the Org of your fork.
   ORG="<my-org>"
@@ -12,68 +11,82 @@ else
   GH_REPO="github.com/${ORG}/${REPO}.git"
 fi
 
+# Determine location of this script
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+echo "Checking if repo needs to be updated"
 echo GH_REPO
 
+# List of branches that this script should try to update. Each of these must have
+# a generator command line associated in the script below.
 BRANCHES="init openAPI"
+
+# Name of project that should be generated. Note, this MUST match the name that is
+# hard-coded in kitura-cli, which will be replaced by a user's chosen project name.
 projectName="Generator-Swiftserver-Projects"
 
-SUCCESS="" # List of successful updates
-FAIL=""    # List of failed updates
-
-# Builds a list of branchs that failed to update (if any)
-function fail () {
-  FAIL="$FAIL $1" && echo "Failed to push to branch: $BRANCH"
-  return 1
-}
-
+# Process each branch
 for BRANCH in $BRANCHES
 do
+  cd "${SCRIPT_DIR}"
+  currentProject="${SCRIPT_DIR}/current/${BRANCH}"
+  newProjectDir="${SCRIPT_DIR}/new/${BRANCH}"
+  newProject="${newProjectDir}/${projectName}"
+
+  # Start from a clean state
+  rm -rf "${currentProject}"
+  mkdir -p "${currentProject}"
+  rm -rf "${newProjectDir}"
+  mkdir -p "${newProject}"
+
+  # Clone the current state of this branch
   echo "Generating project for ${BRANCH}"
-  cd "${TRAVIS_BUILD_DIR}"
-  rm -rf current
-  rm -rf new
-  git clone -b "${BRANCH}" "https://${GITHUB_USERNAME}:${GITHUB_PASSWORD}@${GH_REPO}" current
-  currentProject="$(pwd)/current"
+  git clone -b "${BRANCH}" "https://${GITHUB_USERNAME}:${GITHUB_PASSWORD}@${GH_REPO}" "${currentProject}"
 
-  # Need to create a project directory and move into it so we can run the generator.
-  mkdir -p "new/${projectName}" && cd "new/${projectName}"
-  if [[ "${BRANCH}" == "init" ]]
-  then
-    yo swiftserver --init --skip-build
-  elif [[ "$BRANCH" == "openAPI" ]]
-  then
-    yo swiftserver --app --spec '{ "appName":"'"$projectName"'", "appType":"scaffold", "appDir":".", "openapi":true, "docker":true, "metrics":true, "healthcheck":true }' --skip-build
-    rm spec.json
-  else
+  # Run the generator command associated with this branch name:
+  cd "${newProject}"
+  case "${BRANCH}" in
+  init)
+    yo --no-insight swiftserver --init --skip-build
+    ;;
+  openAPI)
+    yo --no-insight swiftserver --app --spec '{ "appName":"'"$projectName"'", "appType":"scaffold", "appDir":".", "openapi":true, "docker":true, "metrics":true, "healthcheck":true }' --skip-build
+    ;;
+  *)
+    echo "Error - no recipe for branch '${BRANCH}'."
     exit
-  fi
-  # Step back into the travis build directory after generator has finished.
-  cd "${TRAVIS_BUILD_DIR}"
+  esac
+  # Remove files that are excluded from the generated project
+  rm spec.json
 
-  echo "Generate README rtf"
-  pandoc README.md -f markdown_github -t rtf -so README.rtf
-  newProject="$(pwd)/new"
-
-  currentRepo="${currentProject}/${REPO}"
-  newRepo="${newProject}/${projectName}"
-
-  if diff -x '.git' -r "${currentRepo}" "${newRepo}"
+  # Diff the current and newly generated projects. If any files have changed,
+  # they should be committed and pushed to the branch.
+  if diff -x '.git' -r "${currentProject}" "${newProject}"
   then
     echo "Project does not need to be updated"
-    rm -rf "${currentProject}" "${newProject}"
     continue
   fi
 
+  # Files differed - use rsync to update files that have changed
   echo "Project needs to be updated"
-  rsync -av --ignore-times "${newRepo}/" "${currentRepo}/"
-  cd "${currentRepo}"
-  git add -A
-  git commit -m "CRON JOB: Updating generated project"
-  if [[ "$TRAVIS_PULL_REQUEST" == "false" ]]
-  then git push origin "${BRANCH}" || fail "${BRANCH}" || continue
-  fi
-  SUCCESS="$SUCCESS $BRANCH"
-done
+  rsync -avc --delete --exclude '.git' "${newProject}/" "${currentProject}/"
+  
+  # CD to the newly updated project
+  cd "${currentProject}"
+  
+  # Update the README.rtf
+  echo "Generate README rtf"
+  pandoc README.md -f markdown_github -t rtf -so README.rtf
 
-echo Success: $SUCCESS
-echo Failed: $FAIL
+  # Add all changes. Only commit and push if we detect this script is running as
+  # part of a Travis build (and not a pull request).
+  git add -A
+  if [[ "$TRAVIS_PULL_REQUEST" == "false" ]]
+  then
+    git commit -m "CRON JOB: Updating generated project"
+    git push origin "${BRANCH}"
+  else
+    echo "Skipping push (not a cron job). Changes can be inspected in:"
+    echo "  ${currentProject}"
+  fi
+done


### PR DESCRIPTION
Fixes some issues with the `updateRepo.sh` script:
- delete files that should no longer appear in the branch (ie. that are not generated by the current generator version).
- ensure the README.rtf file is updated properly (it needs to be regenerated _after_ the README.md is produced by the generator).
- fix some issues that prevented it from working when running locally.
- add comments to explain what it's doing.

While fixing this, I made a `Dockerfile` to make it easier to test the changes locally.  I've included that too.