### PR TITLE
Import FoundationNetworking for Swift 5.1

### DIFF
--- a/Tests/ApplicationTests/RouteTests.swift
+++ b/Tests/ApplicationTests/RouteTests.swift
@@ -1,4 +1,8 @@
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
 import Kitura
 import KituraNet
 import XCTest


### PR DESCRIPTION
Redo of #29 which was overwritten by (now disabled) nightly generation.